### PR TITLE
Move to last line even if the buffer is not active

### DIFF
--- a/autoload/autoread.vim
+++ b/autoload/autoread.vim
@@ -41,11 +41,10 @@ function! s:autoread_cb(channel, msg) dict abort "{{{1
   else
     call append('$', a:msg)
   endif
+  norm! G
   if switch_buffer
     exe "noa ". curtabnr. "tabnext"
     exe "noa ". curwinnr. "wincmd w"
-  else
-    norm! G
   endif
   call s:OutputMessage()
 endfunction


### PR DESCRIPTION
After all its supposed "tail" and its okay to expect it to tail even if the buffer is not active.
Makes sense for me, as I want to watch some logfiles and dont want to change my buffer and move the cursor myself
Please let me know there are any reservations against this behaviour.